### PR TITLE
fix(workflow): add specific react version in eslint settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,7 @@ module.exports = {
       },
     },
     react: {
-      version: 'detect',
+      version: '18.2.0',
     },
   },
   rules: {


### PR DESCRIPTION
## 🍰 Pullrequest
Gets rid of this warning:
<img width="769" alt="Screenshot 2025-01-25 at 10 42 04" src="https://github.com/user-attachments/assets/fc583aff-3d7a-4151-bb23-cb4e117cb1d9" />

While `detect` sounds like less work, it doesn't seem to work properly with a dev/peerDependency.

