### PR TITLE
fix(release): don't crash when text field is not set

### DIFF
--- a/src/Components/Profile/Subcomponents/ProfileTextView.tsx
+++ b/src/Components/Profile/Subcomponents/ProfileTextView.tsx
@@ -17,9 +17,7 @@ export const ProfileTextView = ({
 }) => {
   const text = get(item, dataField)
 
-  if (typeof text !== 'string') {
-    throw new Error('ProfileTextView: text is not a string')
-  }
+  const parsedText = typeof text !== 'string' ? '' : text
 
   return (
     <div className='tw-my-10 tw-mt-2 tw-px-6'>
@@ -27,7 +25,7 @@ export const ProfileTextView = ({
         <h2 className='tw-text-lg tw-font-semibold'>{heading}</h2>
       )}
       <div className='tw-mt-2 tw-text-sm'>
-        <TextView itemId={item.id} rawText={text} />
+        <TextView itemId={item.id} rawText={parsedText} />
       </div>
     </div>
   )


### PR DESCRIPTION
## 🍰 Pullrequest
Opening a profile with empty text does not crash the app anymore.
However, opening http://localhost:5174/item/b5984f26-3505-4544-b712-63793e6b435a does not show any content. I don't know if this is the intended behaviour? @antontranelis 

### Issues
- fixes #145.

(needed ~10 minutes)