### PR TITLE
fix(workflow): disable typescript sourcemap to get a valid sourcemap

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
       "module": "esnext",
       "target": "ESNext",
       "lib": ["es6", "dom","es2015", "es2016", "es2017", "es2020"],
-      "sourceMap": true,
+      "sourceMap": false,
       "allowJs": false,
       "jsx": "react-jsx",
       "moduleResolution": "node",


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
When running the utopia-map project, we get invalid sourcemap errors:
<img width="783" alt="Screenshot 2025-03-31 at 13 14 48" src="https://github.com/user-attachments/assets/72451174-c034-4c45-adae-5a21351aba41" />
This PR fixes that. It doesn't preserve JSX, unfortunately, so there is room to improve. But it's much better than having nothing.
