### PR TITLE
Fix theme initialization in hook

### DIFF
--- a/lib/src/Components/AppShell/hooks/useTheme.tsx
+++ b/lib/src/Components/AppShell/hooks/useTheme.tsx
@@ -5,8 +5,11 @@ export const useTheme = (defaultTheme = 'default') => {
     const savedTheme = localStorage.getItem('theme')
     const initialTheme = savedTheme ? (JSON.parse(savedTheme) as string) : defaultTheme
     if (initialTheme !== 'default') {
-      document.documentElement.setAttribute('data-theme', defaultTheme)
+      document.documentElement.setAttribute('data-theme', initialTheme)
       localStorage.setItem('theme', JSON.stringify(initialTheme))
+    } else {
+      document.documentElement.removeAttribute('data-theme')
+      localStorage.removeItem('theme')
     }
   }, [defaultTheme])
 }


### PR DESCRIPTION
## Summary
- ensure `useTheme` sets `data-theme` based on the stored or default theme
- reset attribute and localStorage when theme is `default`

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm run test:lint:eslint` *(fails: ESLint couldn't find config)*
- `npm run test:lint:eslint` in frontend *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6852a8486dbc8327b5bcbe1d22b60055