### PR TITLE
Fix router-dom dependency version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11471,7 +11471,7 @@
         "react-leaflet-cluster": "^2.1.0",
         "react-markdown": "^9.0.1",
         "react-photo-album": "^3.0.2",
-        "react-router-dom": "^6.16.0",
+        "react-router-dom": "^6.23.0",
         "react-toastify": "^9.1.3",
         "remark-breaks": "^4.0.0",
         "tiptap-markdown": "^0.8.10",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     tailwindcss(),
   ],
   resolve: {
+    dedupe: ['react', 'react-dom', 'react-router-dom'],
     alias: {
       'utopia-ui': path.resolve(__dirname, '../lib/src'),
       '#components': path.resolve(__dirname, '../lib/src/Components'),

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -37,7 +37,6 @@
         "react-leaflet-cluster": "^2.1.0",
         "react-markdown": "^9.0.1",
         "react-photo-album": "^3.0.2",
-        "react-router-dom": "^6.16.0",
         "react-toastify": "^9.1.3",
         "remark-breaks": "^4.0.0",
         "tiptap-markdown": "^0.8.10",
@@ -11342,23 +11341,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.29.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.29.0.tgz",
-      "integrity": "sha512-pkEbJPATRJ2iotK+wUwHfy0xs2T59YPEN8BQxVCPeBZvK7kfPESRc/nyxzdcxR17hXgUPYx2whMwl+eo9cUdnQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.22.0",
-        "react-router": "6.29.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-toastify": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -94,7 +94,8 @@
   },
   "peerDependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
   },
   "dependencies": {
     "@heroicons/react": "^2.0.17",
@@ -125,7 +126,6 @@
     "react-leaflet-cluster": "^2.1.0",
     "react-markdown": "^9.0.1",
     "react-photo-album": "^3.0.2",
-    "react-router-dom": "^6.16.0",
     "react-toastify": "^9.1.3",
     "remark-breaks": "^4.0.0",
     "tiptap-markdown": "^0.8.10",


### PR DESCRIPTION
## Summary
- move `react-router-dom` to peerDependencies in the library
- update frontend build config to dedupe router packages
- sync package locks

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` in lib *(fails: rollup not found)*
- `npm run build` in frontend *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e60e1523883279798cc123e9a5ad5