### PR TITLE
fix(lib): auto close update position toast

### DIFF
--- a/app/src/ModalContent.tsx
+++ b/app/src/ModalContent.tsx
@@ -17,6 +17,14 @@ export function Welcome1({ clickAction1, map }: ChapterProps) {
       {map.custom_text ? (
         <>
           <TextView rawText={map.custom_text}></TextView>
+          <div className='tw:grid'>
+            <label
+              className='tw:btn tw:btn-primary tw:place-self-end tw:mt-4'
+              onClick={() => clickAction1()}
+            >
+              Close
+            </label>
+          </div>
         </>
       ) : (
         <>

--- a/app/src/ModalContent.tsx
+++ b/app/src/ModalContent.tsx
@@ -17,14 +17,6 @@ export function Welcome1({ clickAction1, map }: ChapterProps) {
       {map.custom_text ? (
         <>
           <TextView rawText={map.custom_text}></TextView>
-          <div className='tw:grid'>
-            <label
-              className='tw:btn tw:btn-primary tw:place-self-end tw:mt-4'
-              onClick={() => clickAction1()}
-            >
-              Close
-            </label>
-          </div>
         </>
       ) : (
         <>

--- a/lib/src/Components/Map/Subcomponents/SelectPosition.tsx
+++ b/lib/src/Components/Map/Subcomponents/SelectPosition.tsx
@@ -20,7 +20,7 @@ export const SelectPosition = ({
       </label>
       <div className='tw:alert tw:bg-base-100 tw:text-base-content'>
         <div>
-          {selectNewItemPosition && 'text' in selectNewItemPosition && (
+          {selectNewItemPosition && 'layer' in selectNewItemPosition && (
             <span className='tw:text-lg'>
               Select new position of <b>{selectNewItemPosition.name}</b> on the map!
             </span>

--- a/lib/src/Components/Map/hooks/useSelectPosition.tsx
+++ b/lib/src/Components/Map/hooks/useSelectPosition.tsx
@@ -69,7 +69,7 @@ function useSelectPositionManager(): {
           })
         setSelectPosition(null)
       }
-      if ('text' in selectPosition) {
+      if ('layer' in selectPosition) {
         // if selectPosition is an Item
         const position =
           mapClicked?.position.lng &&

--- a/lib/src/Components/Map/hooks/useSelectPosition.tsx
+++ b/lib/src/Components/Map/hooks/useSelectPosition.tsx
@@ -101,9 +101,9 @@ function useSelectPositionManager(): {
         success = true
       } catch (error: unknown) {
         if (error instanceof Error) {
-          toast.update(toastId, { render: error.message, type: 'error' })
+          toast.update(toastId, { render: error.message, type: 'error', autoClose: 5000 })
         } else if (typeof error === 'string') {
-          toast.update(toastId, { render: error, type: 'error' })
+          toast.update(toastId, { render: error, type: 'error', autoClose: 5000 })
         } else {
           throw error
         }
@@ -115,6 +115,7 @@ function useSelectPositionManager(): {
           render: 'Item position updated',
           type: 'success',
           isLoading: false,
+          autoClose: 5000,
         })
         setSelectPosition(null)
         setMarkerClicked(null)
@@ -125,6 +126,8 @@ function useSelectPositionManager(): {
         render: "you don't have permission to add items to " + markerClicked?.name,
         type: 'error',
         isLoading: false,
+        autoClose: 5000,
+        closeButton: true,
       })
     }
   }
@@ -140,16 +143,34 @@ function useSelectPositionManager(): {
       success = true
     } catch (error: unknown) {
       if (error instanceof Error) {
-        toast.update(toastId, { render: error.message, type: 'error', isLoading: false })
+        toast.update(toastId, {
+          render: error.message,
+          type: 'error',
+          isLoading: false,
+          autoClose: 5000,
+          closeButton: true,
+        })
       } else if (typeof error === 'string') {
-        toast.update(toastId, { render: error, type: 'error', isLoading: false })
+        toast.update(toastId, {
+          render: error,
+          type: 'error',
+          isLoading: false,
+          autoClose: 5000,
+          closeButton: true,
+        })
       } else {
         throw error
       }
     }
     if (success) {
       updateItem(updatedItem)
-      toast.update(toastId, { render: 'Item position updated', type: 'success', isLoading: false })
+      toast.update(toastId, {
+        render: 'Item position updated',
+        type: 'success',
+        isLoading: false,
+        autoClose: 5000,
+        closeButton: true,
+      })
     }
   }
 
@@ -168,16 +189,34 @@ function useSelectPositionManager(): {
           success = true
         } catch (error: unknown) {
           if (error instanceof Error) {
-            toast.update(toastId, { render: error.message, type: 'error', isLoading: false })
+            toast.update(toastId, {
+              render: error.message,
+              type: 'error',
+              isLoading: false,
+              autoClose: 5000,
+              closeButton: true,
+            })
           } else if (typeof error === 'string') {
-            toast.update(toastId, { render: error, type: 'error', isLoading: false })
+            toast.update(toastId, {
+              render: error,
+              type: 'error',
+              isLoading: false,
+              autoClose: 5000,
+              closeButton: true,
+            })
           } else {
             throw error
           }
         }
         if (success) {
           updateItem({ ...markerClicked, relations: newRelations })
-          toast.update(toastId, { render: 'Item linked', type: 'success', isLoading: false })
+          toast.update(toastId, {
+            render: 'Item linked',
+            type: 'success',
+            isLoading: false,
+            autoClose: 5000,
+            closeButton: true,
+          })
         }
       }
     }


### PR DESCRIPTION
- [x]  The toast by updating an items position was not disappearing 
- [x] Bugfix: Set position for new created items, without text (working now)