### PR TITLE
Update TextPreview markdown handling

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -36,6 +36,11 @@ It is the base of [Utopia Map](https://github.com/utopia-os/utopia-map) and [Uto
 
 ![Utopia UI Components](Components.svg)
 
+### TextPreview
+
+The `TextPreview` component now accepts an optional `maxChars` property to limit the
+displayed text length. The default value is `100` characters.
+
 ## Map Component
 The map shows various Layers (like places, events, profiles ...) of Items at their respective position whith nice and informative Popup and Profiles.
 

--- a/lib/src/Components/Map/Subcomponents/ItemPopupComponents/TextPreview.spec.tsx
+++ b/lib/src/Components/Map/Subcomponents/ItemPopupComponents/TextPreview.spec.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+import { TextPreview } from './TextPreview'
+
+import type { Item } from '#types/Item'
+import type { Tag } from '#types/Tag'
+
+vi.mock('#components/Map/hooks/useTags', () => ({
+  useTags: () => [{ id: '1', name: 'tag', color: '#000' }] as Tag[],
+}))
+
+vi.mock('#components/Map/hooks/useFilter', () => ({
+  useAddFilterTag: () => vi.fn(),
+}))
+
+describe('<TextPreview />', () => {
+  it('truncates respecting maxChars', () => {
+    const item: Item = { id: '1', name: 't', text: 'This is a very long text with a link [here](https://example.com) and more words.' }
+    const { container } = render(<TextPreview item={item} maxChars={20} />)
+    expect((container.textContent ?? '').length).toBeLessThanOrEqual(20)
+  })
+
+  it('renders hashtags and hyperlinks', () => {
+    const item: Item = { id: '1', name: 't', text: 'Visit [site](https://example.com) #tag' }
+    const { container } = render(<TextPreview item={item} maxChars={100} />)
+    const links = container.querySelectorAll('a')
+    expect(links.length).toBe(2)
+    expect(links[0].getAttribute('href')).toBe('https://example.com')
+    expect(links[1].className).toContain('hashtag')
+  })
+
+  it('removes tables', () => {
+    const item: Item = { id: '1', name: 't', text: '<table><tr><td>bad</td></tr></table>good' }
+    const { container } = render(<TextPreview item={item} maxChars={100} />)
+    expect(container.textContent).not.toContain('bad')
+    expect(container.textContent).toContain('good')
+  })
+})

--- a/lib/src/Components/Map/Subcomponents/ItemPopupComponents/TextPreview.tsx
+++ b/lib/src/Components/Map/Subcomponents/ItemPopupComponents/TextPreview.tsx
@@ -1,31 +1,152 @@
+import { createRequire } from 'module'
+import { useMemo } from 'react'
+import htmlTruncate from 'html-truncate'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+
 import { useAddFilterTag } from '#components/Map/hooks/useFilter'
 import { useTags } from '#components/Map/hooks/useTags'
 import { decodeTag } from '#utils/FormatTags'
+import { hashTagRegex } from '#utils/HashTagRegex'
 
 import type { Item } from '#types/Item'
 import type { Tag } from '#types/Tag'
 
+const require = createRequire(import.meta.url)
+let remarkGfm: any
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  remarkGfm = require('remark-gfm')
+} catch {
+  remarkGfm = undefined
+}
+
 const MAX_CHARS = 100
+
+function sanitizeHtml(html: string) {
+  return html.replace(/<table[^]*?<\/table>/gis, '')
+}
+
+function mdastToHtml(node: any): string {
+  switch (node.type) {
+    case 'root':
+      return node.children.map(mdastToHtml).join('')
+    case 'paragraph':
+      return node.children.map(mdastToHtml).join('')
+    case 'text':
+      return node.value
+    case 'strong':
+    case 'emphasis':
+      return node.children.map(mdastToHtml).join('')
+    case 'link':
+      return `<a href="${node.url}">${node.children.map(mdastToHtml).join('')}</a>`
+    case 'break':
+      return ' '
+    case 'html':
+      return node.value
+    case 'list':
+      return node.children.map(mdastToHtml).join(' ')
+    case 'listItem':
+      return node.children.map(mdastToHtml).join(' ')
+    default:
+      return ''
+  }
+}
+
+function htmlToReact(
+  html: string,
+  tags: Tag[],
+  itemId?: string,
+): React.ReactNode[] {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(html, 'text/html')
+
+  const traverse = (node: ChildNode): React.ReactNode => {
+    if (node.nodeType === 3) {
+      const text = node.textContent ?? ''
+      const parts = text.split(hashTagRegex)
+      return parts.map((part, i) => {
+        if (hashTagRegex.test(part)) {
+          const tag = tags.find(
+            (t) => `#${t.name.toLowerCase()}` === part.toLowerCase(),
+          )
+          return tag ? (
+            <HashTag key={`${part}-${i}`} tag={tag} itemId={itemId}>
+              {part}
+            </HashTag>
+          ) : (
+            part
+          )
+        }
+        return part
+      })
+    }
+
+    if (node.nodeType === 1) {
+      const el = node as HTMLElement
+
+      if (el.tagName.toLowerCase() === 'a') {
+        const href = el.getAttribute('href') ?? ''
+        return (
+          <a href={href}>{Array.from(el.childNodes).map(traverse)}</a>
+        )
+      }
+
+      if (
+        el.tagName.toLowerCase() === 'span' &&
+        (el.getAttribute('data-type') === 'mention' || el.classList.contains('mention'))
+      ) {
+        const id = el.getAttribute('data-id') ?? el.textContent?.replace('#', '') ?? ''
+        const tag = tags.find((t) => t.name.toLowerCase() === id.toLowerCase())
+        return (
+          <HashTag key={`${id}`} tag={tag ?? { id: id, name: id, color: 'inherit' }} itemId={itemId}>
+            #{id}
+          </HashTag>
+        )
+      }
+
+      if (el.tagName.toLowerCase() === 'table') {
+        return null
+      }
+
+      return <>{Array.from(el.childNodes).map(traverse)}</>
+    }
+
+    return null
+  }
+
+  return Array.from(doc.body.childNodes).map(traverse)
+}
 
 /**
  * @category Map
+ * @param maxChars - maximum number of characters to display
  */
-export const TextPreview = ({ item }: { item: Item }) => {
+export const TextPreview = ({
+  item,
+  maxChars = MAX_CHARS,
+}: {
+  item: Item
+  maxChars?: number
+}) => {
   const tags = useTags()
 
-  if (!item.text) return ''
-  const s = item.text
-    .replace(/`([^`]+)`/g, '$1')
-    .replace(/<\/?[^>]+>/g, '') // übrige HTML
-    .replace(/!\[.*?\]\(.*?\)/g, '') // Remove images
-    .replace(/(`{1,3})(.*?)\1/g, '$2') // Remove inline code
-    .replace(/(\*{1,2}|_{1,2})(.*?)\1/g, '$2') // Remove bold and italic
-    .replace(/(#+)\s+(.*)/g, '$2') // Remove headers
-    .replace(/>\s+(.*)/g, '$1') // Remove blockquotes
-    .replace(/^\s*\n/gm, '\n') // Preserve empty lines
-    .replace(/(\r\n|\n|\r)/gm, '\n') // Preserve line breaks
+  const nodes = useMemo(() => {
+    if (!item.text) return null
 
-  return s
+    const processor = unified().use(remarkParse)
+    if (remarkGfm) processor.use(remarkGfm)
+
+    const ast = processor.parse(item.text)
+    const html = sanitizeHtml(mdastToHtml(ast))
+    const truncated = htmlTruncate(html, maxChars, {
+      reserveLastWord: true,
+    })
+
+    return htmlToReact(truncated, tags, item.id)
+  }, [item.text, maxChars, tags, item.id])
+
+  return <span>{nodes}</span>
 }
 
 const HashTag = ({ children, tag, itemId }: { children: string; tag: Tag; itemId?: string }) => {


### PR DESCRIPTION
## Summary
- enhance `TextPreview` component with markdown parsing and truncation
- document new `maxChars` prop in README
- add unit tests for `TextPreview`

## Testing
- `npm run test:unit --prefix lib` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68676f495fac8327858b2732699a1afb