### PR TITLE
feat(lib): add support for external images in items

### DIFF
--- a/lib/src/Components/Map/Subcomponents/ItemPopupComponents/HeaderView.tsx
+++ b/lib/src/Components/Map/Subcomponents/ItemPopupComponents/HeaderView.tsx
@@ -57,7 +57,9 @@ export function HeaderView({
 
   const [imageLoaded, setImageLoaded] = useState(false)
 
-  const avatar = item.image_external || (item.image && appState.assetsApi.url + item.image + '?width=160&heigth=160')
+  const avatar =
+    item.image_external ||
+    (item.image && appState.assetsApi.url + item.image + '?width=160&heigth=160')
   const title = item.name
   const subtitle = item.subname
 

--- a/lib/src/Components/Map/Subcomponents/ItemPopupComponents/HeaderView.tsx
+++ b/lib/src/Components/Map/Subcomponents/ItemPopupComponents/HeaderView.tsx
@@ -57,7 +57,7 @@ export function HeaderView({
 
   const [imageLoaded, setImageLoaded] = useState(false)
 
-  const avatar = item.image && appState.assetsApi.url + item.image + '?width=160&heigth=160'
+  const avatar = item.image_external || (item.image && appState.assetsApi.url + item.image + '?width=160&heigth=160')
   const title = item.name
   const subtitle = item.subname
 

--- a/lib/src/types/Item.d.ts
+++ b/lib/src/types/Item.d.ts
@@ -46,6 +46,7 @@ export interface Item {
   slug?: string
   user_created?: UserItem
   image?: string
+  image_external?: string
   group_type?: string
   offers?: TagIds
   needs?: TagIds


### PR DESCRIPTION
## Summary
- Add `image_external` field to Item type definition
- Update HeaderView component to prefer external images over internal ones when available

## Changes
- **lib/src/types/Item.d.ts**: Added `image_external?: string` field to Item interface
- **lib/src/Components/Map/Subcomponents/ItemPopupComponents/HeaderView.tsx**: Modified avatar logic to use `item.image_external || (item.image && ...)` pattern

## Test plan
- [x] Verify that items with `image_external` field display the external image
- [x] Verify that items without `image_external` fall back to internal image
- [x] Verify that items without both fields handle gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)