### PR TITLE
fix(lib): fix behavior of modal o close

### DIFF
--- a/lib/src/Components/Map/Subcomponents/Controls/LocateControl.tsx
+++ b/lib/src/Components/Map/Subcomponents/Controls/LocateControl.tsx
@@ -260,7 +260,10 @@ export const LocateControl = (): JSX.Element => {
       <DialogModal
         title='Location found'
         isOpened={showLocationModal}
-        onClose={() => setShowLocationModal(false)}
+        onClose={() => {
+          setShowLocationModal(false)
+          setHasDeclinedModal(true)
+        }}
         showCloseButton={true}
         closeOnClickOutside={false}
         className='tw:bottom-1/3 tw:mx-4 tw:sm:mx-auto'


### PR DESCRIPTION
When clicking the small "x" to close the modal, it should behave the same way as when clicking no

<img width="984" height="472" alt="image" src="https://github.com/user-attachments/assets/ec267548-bac6-4d3a-890d-8dafd720a61e" />
