### PR TITLE
fix(lib): reinsert uuid to fix notifications in backend

### DIFF
--- a/lib/src/Components/Map/Subcomponents/ItemFormPopup.tsx
+++ b/lib/src/Components/Map/Subcomponents/ItemFormPopup.tsx
@@ -159,8 +159,11 @@ export function ItemFormPopup(props: Props) {
             popupForm.layer.api?.updateItem!({ ...formItem, id: existingUserItem.id }) ??
             Promise.resolve({} as Item)
         : () =>
-            popupForm.layer.api?.createItem!({ ...formItem, name: itemName }) ??
-            Promise.resolve({} as Item)
+            popupForm.layer.api?.createItem!({
+              ...formItem,
+              name: itemName,
+              id: crypto.randomUUID(),
+            }) ?? Promise.resolve({} as Item)
 
       const result = await handleApiOperation(
         operation,


### PR DESCRIPTION
Removing the UUID from the itemCreate function in  `ItemFormPopup` function has resulted in notifications no longer being triggered in some cases.