### PR TITLE
fix(lib): fix user_created reset when updating other users profile marker

### DIFF
--- a/lib/src/Components/Map/Subcomponents/ItemFormPopup.tsx
+++ b/lib/src/Components/Map/Subcomponents/ItemFormPopup.tsx
@@ -127,14 +127,14 @@ export function ItemFormPopup(props: Props) {
         const itemWithLayer = {
           ...result.data,
           layer: popupForm.layer,
-          user_created: user ?? undefined,
+          user_created: formItem.user_created,
         }
         updateItem(itemWithLayer)
       }
 
       return result.success
     },
-    [popupForm, handleApiOperation, updateItem, user],
+    [popupForm, handleApiOperation, updateItem],
   )
 
   // Create new item or update existing user profile

--- a/lib/src/Components/Map/hooks/useSelectPosition.tsx
+++ b/lib/src/Components/Map/hooks/useSelectPosition.tsx
@@ -178,9 +178,8 @@ function useSelectPositionManager(): {
     )
 
     if (result.success && result.data) {
-      // Find the layer object by ID from server response
       const layer = layers.find((l) => l.id === (result.data!.layer as unknown as string))
-      const itemWithLayer = { ...result.data, layer, user_created: user ?? undefined }
+      const itemWithLayer = { ...result.data, layer, user_created: updatedItem.user_created }
       updateItem(itemWithLayer)
     }
   }

--- a/lib/src/Components/Map/hooks/useSelectPosition.tsx
+++ b/lib/src/Components/Map/hooks/useSelectPosition.tsx
@@ -144,7 +144,7 @@ function useSelectPositionManager(): {
       if (result.success && result.data) {
         // Find the layer object by ID from server response
         const layer = layers.find((l) => l.id === (result.data!.layer as unknown as string))
-        const itemWithLayer = { ...result.data, layer, user_created: user ?? undefined }
+        const itemWithLayer = { ...result.data, layer, user_created: updatedItem.user_created }
         updateItem(itemWithLayer)
         await linkItem(updatedItem.id)
         setSelectPosition(null)
@@ -205,7 +205,7 @@ function useSelectPositionManager(): {
         if (result.success && result.data) {
           // Find the layer object by ID from server response
           const layer = layers.find((l) => l.id === (result.data!.layer as unknown as string))
-          const itemWithLayer = { ...result.data, layer, user_created: user ?? undefined }
+          const itemWithLayer = { ...result.data, layer, user_created: markerClicked.user_created }
           updateItem(itemWithLayer)
         }
       }

--- a/lib/src/Components/Map/hooks/useSelectPosition.tsx
+++ b/lib/src/Components/Map/hooks/useSelectPosition.tsx
@@ -11,8 +11,6 @@
 import { createContext, useContext, useEffect, useState, useCallback } from 'react'
 import { toast } from 'react-toastify'
 
-import { useAuth } from '#components/Auth/useAuth'
-
 import { useUpdateItem } from './useItems'
 import { useLayers } from './useLayers'
 import { useHasUserPermission } from './usePermissions'
@@ -49,7 +47,6 @@ function useSelectPositionManager(): {
   const updateItem = useUpdateItem()
   const hasUserPermission = useHasUserPermission()
   const layers = useLayers()
-  const { user } = useAuth()
 
   // Handle API operations with consistent error handling and return response data
   const handleApiOperation = useCallback(

--- a/lib/src/Components/Profile/ProfileForm.tsx
+++ b/lib/src/Components/Profile/ProfileForm.tsx
@@ -198,8 +198,8 @@ export function ProfileForm() {
                   state={state}
                   setState={setState}
                   updatePermission={updatePermission}
-                  linkItem={(id: string) => linkItem(id, item, updateItem, user)}
-                  unlinkItem={(id: string) => unlinkItem(id, item, updateItem, user)}
+                  linkItem={(id: string) => linkItem(id, item, updateItem)}
+                  unlinkItem={(id: string) => unlinkItem(id, item, updateItem)}
                   setUrlParams={setUrlParams}
                 ></TabsForm>
               )}

--- a/lib/src/Components/Profile/ProfileView.tsx
+++ b/lib/src/Components/Profile/ProfileView.tsx
@@ -12,7 +12,6 @@ import { useEffect, useState } from 'react'
 import { useMap } from 'react-leaflet'
 import { useLocation, useNavigate } from 'react-router-dom'
 
-import { useAuth } from '#components/Auth/useAuth'
 import { useClusterRef } from '#components/Map/hooks/useClusterRef'
 import { useItems, useRemoveItem, useUpdateItem } from '#components/Map/hooks/useItems'
 import { useLayers } from '#components/Map/hooks/useLayers'
@@ -52,7 +51,6 @@ export function ProfileView({ attestationApi }: { attestationApi?: ItemsApi<any>
   const map = useMap()
   const selectPosition = useSelectPosition()
   const removeItem = useRemoveItem()
-  const { user } = useAuth()
   const tags = useTags()
   const navigate = useNavigate()
   const hasUserPermission = useHasUserPermission()
@@ -210,8 +208,8 @@ export function ProfileView({ attestationApi }: { attestationApi?: ItemsApi<any>
                 needs={needs}
                 relations={relations}
                 updatePermission={updatePermission}
-                linkItem={(id) => linkItem(id, item, updateItem, user)}
-                unlinkItem={(id) => unlinkItem(id, item, updateItem, user)}
+                linkItem={(id) => linkItem(id, item, updateItem)}
+                unlinkItem={(id) => unlinkItem(id, item, updateItem)}
               />
             )}
           </>

--- a/lib/src/Components/Profile/itemFunctions.ts
+++ b/lib/src/Components/Profile/itemFunctions.ts
@@ -139,7 +139,7 @@ export const linkItem = async (id: string, item: Item, updateItem, user) => {
       ...result.data,
       layer,
       relations: newRelations,
-      user_created: user ?? undefined,
+      user_created: item.user_created,
     }
     updateItem(itemWithLayer)
   }
@@ -163,7 +163,7 @@ export const unlinkItem = async (id: string, item: Item, updateItem, user) => {
   if (result.success && result.data) {
     // Find the layer object by ID from server response or use existing layer
     const layer = item.layer
-    const itemWithLayer = { ...result.data, layer, user_created: user ?? undefined }
+    const itemWithLayer = { ...result.data, layer, user_created: item.user_created }
     updateItem(itemWithLayer)
   }
 }
@@ -308,7 +308,7 @@ export const onUpdateItem = async (
         layer: item.layer,
         markerIcon: state.marker_icon,
         gallery: state.gallery,
-        user_created: user ?? undefined,
+        user_created: item.user_created,
       }
       updateItem(itemWithLayer)
       navigate(`/item/${item.id}${params && '?' + params}`)

--- a/lib/src/Components/Profile/itemFunctions.ts
+++ b/lib/src/Components/Profile/itemFunctions.ts
@@ -116,7 +116,7 @@ export const submitNewItem = async (
   setAddItemPopupType('')
 }
 
-export const linkItem = async (id: string, item: Item, updateItem, user) => {
+export const linkItem = async (id: string, item: Item, updateItem) => {
   const newRelations = item.relations ?? []
   newRelations?.push({ items_id: item.id, related_items_id: id })
   const updatedItem = { id: item.id, relations: newRelations }
@@ -145,7 +145,7 @@ export const linkItem = async (id: string, item: Item, updateItem, user) => {
   }
 }
 
-export const unlinkItem = async (id: string, item: Item, updateItem, user) => {
+export const unlinkItem = async (id: string, item: Item, updateItem) => {
   const newRelations = item.relations?.filter((r) => r.related_items_id !== id)
   const updatedItem = { id: item.id, relations: newRelations }
 


### PR DESCRIPTION
When updating other users items as admin, the admin was set as user_created for this item in local state.

fixes #367