### PR TITLE
fix(backend): pin directus sync extension to last current version before current breaking changes

### DIFF
--- a/backend/extensions/package.json
+++ b/backend/extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extensions",
   "dependencies": {
-    "directus-extension-sync": "^3.0.4"
+    "directus-extension-sync": "3.0.4"
   }
 }

--- a/backend/seed.sh
+++ b/backend/seed.sh
@@ -16,7 +16,7 @@ PROJECT_NAME="${PROJECT:-development}"
 PROJECT_FOLDER=$SCRIPT_DIR/directus-config/$PROJECT_NAME
 
 echo "Sync collections"
-npx directus-sync@3.4.0 push \
+npx directus-sync push \
   --dump-path $PROJECT_FOLDER \
   --directus-url $DIRECTUS_URL \
   --directus-email $DIRECTUS_EMAIL \

--- a/backend/seed.sh
+++ b/backend/seed.sh
@@ -16,7 +16,7 @@ PROJECT_NAME="${PROJECT:-development}"
 PROJECT_FOLDER=$SCRIPT_DIR/directus-config/$PROJECT_NAME
 
 echo "Sync collections"
-npx directus-sync push \
+npx directus-sync@3.4.0 push \
   --dump-path $PROJECT_FOLDER \
   --directus-url $DIRECTUS_URL \
   --directus-email $DIRECTUS_EMAIL \

--- a/backend/seed.sh
+++ b/backend/seed.sh
@@ -16,7 +16,7 @@ PROJECT_NAME="${PROJECT:-development}"
 PROJECT_FOLDER=$SCRIPT_DIR/directus-config/$PROJECT_NAME
 
 echo "Sync collections"
-npx directus-sync push \
+npx directus-sync@3.4.0 push \
   --dump-path $PROJECT_FOLDER \
   --directus-url $DIRECTUS_URL \
   --directus-email $DIRECTUS_EMAIL \
@@ -24,7 +24,7 @@ npx directus-sync push \
   || exit 1
 
 echo "Seed data"
-npx directus-sync seed push \
+npx directus-sync@3.4.0 seed push \
   --seed-path $PROJECT_FOLDER/seed \
   --directus-url $DIRECTUS_URL \
   --directus-email $DIRECTUS_EMAIL \


### PR DESCRIPTION
## 🍰 Pullrequest
The recent new release of [Directus' sync extension](https://github.com/tractr/directus-sync/releases/tag/directus-sync%403.4.1) breaks our backend seeding mechanism (see #404).
This reveals the fragility of our Directus usage in relation to their development.
We should stabilize our mechanisms to be more robust towards that.

### Issues
- fixes #404
- relates #402

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
