### PR TITLE
fix(backend): demonstrate backend seed fail due to directus extension breaking changes

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -14,6 +14,7 @@ cd backend
 In order to pull data from your locally running backend (see [docker-compose](../app/docker-compose.yml)) to your local harddrive, you can run the following command
 
 
+
 ```
 npx directus-sync pull \
   --dump-path ./directus-config/development \


### PR DESCRIPTION
## 🍰 Pullrequest
This pull request with just changing the `backend/README.md` demonstrates the current breaking changes of the Directus sync extension dependency [`directus-extension-sync` / `directus-sync`](https://github.com/tractr/directus-sync/releases/tag/directus-sync%403.4.1) causing our seeding mechanism to fail.

Do not merge.
After #403 is merged or the issue addressed more sustainable, this pull request can be closed.

### Issues
- relate
  #402
  #403