### PR TITLE
refactor(other): adapt dependabot configuration to work with npm workspaces correctly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,7 @@
 version: 2
 updates:
-  # ============================================================================
-  # NPM ECOSYSTEM - Main Application & Library
-  # ============================================================================
-  
-  # Main App (Frontend)
   - package-ecosystem: "npm"
-    directory: "/app"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "wednesday"
@@ -24,26 +19,6 @@ updates:
         patterns:
           - "@typescript-eslint/parser"
           - "@typescript-eslint/eslint-plugin"
-    labels:
-      - "dependencies"
-      - "javascript"
-
-  # Library (utopia-ui)
-  - package-ecosystem: "npm"
-    directory: "/lib"
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-      time: "03:00"
-      timezone: "Europe/Berlin"
-    open-pull-requests-limit: 99
-    groups:
-      react-ecosystem:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
       tiptap:
         patterns:
           - "@tiptap/core"
@@ -51,106 +26,9 @@ updates:
           - "@tiptap/pm"
           - "@tiptap/react"
           - "@tiptap/starter-kit"
-      typescript-eslint:
-        patterns:
-          - "@typescript-eslint/parser"
-          - "@typescript-eslint/eslint-plugin"
     labels:
       - "dependencies"
       - "javascript"
-
-  # Backend Extensions
-  - package-ecosystem: "npm"
-    directory: "/backend/extensions"
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-      time: "03:00"
-      timezone: "Europe/Berlin"
-    open-pull-requests-limit: 99
-    labels:
-      - "dependencies"
-      - "javascript"
-
-  # Cypress E2E Tests
-  - package-ecosystem: "npm"
-    directory: "/cypress"
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-      time: "03:00"
-      timezone: "Europe/Berlin"
-    open-pull-requests-limit: 99
-    labels:
-      - "dependencies"
-      - "javascript"
-  # ============================================================================
-  # NPM ECOSYSTEM - Library Examples (Lower Priority)
-  # ============================================================================
-
-  # Example 1: Basic Map
-  - package-ecosystem: "npm"
-    directory: "/lib/examples/1-basic-map"
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-      time: "03:00"
-      timezone: "Europe/Berlin"
-    open-pull-requests-limit: 99
-    groups:
-      react-ecosystem:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-    labels:
-      - "dependencies"
-      - "javascript"
-
-  # Example 2: Static Layers
-  - package-ecosystem: "npm"
-    directory: "/lib/examples/2-static-layers"
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-      time: "03:00"
-      timezone: "Europe/Berlin"
-    open-pull-requests-limit: 99
-    groups:
-      react-ecosystem:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-    labels:
-      - "dependencies"
-      - "javascript"
-
-  # Example 3: Tags
-  - package-ecosystem: "npm"
-    directory: "/lib/examples/3-tags"
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-      time: "03:00"
-      timezone: "Europe/Berlin"
-    open-pull-requests-limit: 99
-    groups:
-      react-ecosystem:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-    labels:
-      - "dependencies"
-      - "javascript"
-
-  # ============================================================================
-  # GITHUB ACTIONS ECOSYSTEM
-  # ============================================================================
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Motivation
Aftersetting up Dependabot we are facing several bum PRs with workflows failing due to inconsistencies with the root `package-lock.json`file as in [this example](https://github.com/utopia-os/utopia-map/actions/runs/19495312532/job/55796004761?pr=448):
```
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm error
npm error Invalid: lock file's react-image-crop@10.1.8 does not satisfy react-image-crop@11.0.10
npm error Invalid: lock file's @types/node@22.18.8 does not satisfy @types/node@24.10.1
npm error Missing: typescript@5.9.3 from lock file
npm error Missing: undici-types@7.16.0 from lock file
```
Cause of that were the separate NPM package ecosystem entries in the `dependabot.yml`file, especially for the workspace directories `app/` and `lib/`.

Consolidating them to a single NPM ecosystem entrysolves the issue.


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
