### PR TITLE
fix(workflow): replace fixed wait for directus to be actually ready in seeding workflow

### DIFF
--- a/.github/workflows/test.backend.seed.yml
+++ b/.github/workflows/test.backend.seed.yml
@@ -39,11 +39,8 @@ jobs:
           mkdir -p ./data/uploads
           sudo chmod 777 -R ./data
           docker compose -f docker-compose.yml up -d
-          npx directus-sync@3.4.0 wait-server-ready \
-            --directus-url http://localhost:8055 \
-            --directus-email admin@it4c.dev \
-            --directus-password admin123 \
-            --timeout 120
+          # Wait for Directus to be ready using health endpoint polling
+          timeout 120 bash -c 'until curl -f http://localhost:8055/server/health; do echo "Waiting for Directus..."; sleep 5; done'
           cd backend && ./push.sh && ./seed.sh
         working-directory: ${{env.WORKING_DIRECTORY}}
 

--- a/.github/workflows/test.backend.seed.yml
+++ b/.github/workflows/test.backend.seed.yml
@@ -39,7 +39,11 @@ jobs:
           mkdir -p ./data/uploads
           sudo chmod 777 -R ./data
           docker compose -f docker-compose.yml up -d
-          sleep 5
+          npx directus-sync@3.4.0 wait-server-ready \
+            --directus-url http://localhost:8055 \
+            --directus-email admin@it4c.dev \
+            --directus-password admin123 \
+            --timeout 120
           cd backend && ./push.sh && ./seed.sh
         working-directory: ${{env.WORKING_DIRECTORY}}
 


### PR DESCRIPTION
## Motivation
The backend seeding worklofw fails due to [the fixed wait for Directus to be actually ready](https://github.com/utopia-os/utopia-map/blob/b44b479932d3f44ebecd0659ac5124722bd6b074/.github/workflows/test.backend.seed.yml#L42).

By replacing it by the less staticmore reliable bash health polling solution thisissue can be solved. 

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
