### PR TITLE
refactor(lib): migrate to native @tiptap/markdown extension

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -103,11 +103,11 @@
     "@maplibre/maplibre-gl-leaflet": "^0.1.3",
     "@tiptap/core": "^3.13.0",
     "@tiptap/extension-bubble-menu": "^3.13.0",
-    "@tiptap/extension-color": "^3.13.0",
     "@tiptap/extension-image": "^3.13.0",
     "@tiptap/extension-link": "^3.13.0",
     "@tiptap/extension-placeholder": "^3.13.0",
     "@tiptap/extension-youtube": "^3.13.0",
+    "@tiptap/markdown": "^3.15.3",
     "@tiptap/pm": "^3.6.5",
     "@tiptap/react": "^3.13.0",
     "@tiptap/starter-kit": "^3.13.0",
@@ -130,7 +130,6 @@
     "react-qr-code": "^2.0.16",
     "react-toastify": "^9.1.3",
     "remark-breaks": "^4.0.0",
-    "tiptap-markdown": "^0.9.0",
     "yet-another-react-lightbox": "^3.28.0"
   },
   "imports": {

--- a/lib/src/Components/Input/RichTextEditor.tsx
+++ b/lib/src/Components/Input/RichTextEditor.tsx
@@ -1,16 +1,13 @@
-import { Color } from '@tiptap/extension-color'
 import { Image } from '@tiptap/extension-image'
 import { Link } from '@tiptap/extension-link'
 import { Placeholder } from '@tiptap/extension-placeholder'
+import { Markdown } from '@tiptap/markdown'
 import { EditorContent, useEditor } from '@tiptap/react'
 import { StarterKit } from '@tiptap/starter-kit'
 import { useEffect } from 'react'
-import { Markdown } from 'tiptap-markdown'
 
 import { InputLabel } from './InputLabel'
 import { TextEditorMenu } from './TextEditorMenu'
-
-import type { MarkdownStorage } from 'tiptap-markdown'
 
 interface RichTextEditorProps {
   labelTitle?: string
@@ -22,11 +19,6 @@ interface RichTextEditorProps {
   updateFormValue?: (value: string) => void
 }
 
-declare module '@tiptap/core' {
-  interface Storage {
-    markdown: MarkdownStorage
-  }
-}
 
 /**
  * @category Input
@@ -40,7 +32,7 @@ export function RichTextEditor({
   updateFormValue,
 }: RichTextEditorProps) {
   const handleChange = () => {
-    let newValue: string | undefined = editor.storage.markdown.getMarkdown()
+    let newValue: string | undefined = editor.getMarkdown()
 
     const regex = /!\[.*?\]\(.*?\)/g
     newValue = newValue.replace(regex, (match: string) => match + '\n\n')
@@ -51,7 +43,6 @@ export function RichTextEditor({
 
   const editor = useEditor({
     extensions: [
-      Color.configure({ types: ['textStyle', 'listItem'] }),
       StarterKit.configure({
         bulletList: {
           keepMarks: true,
@@ -62,11 +53,7 @@ export function RichTextEditor({
           keepAttributes: false,
         },
       }),
-      Markdown.configure({
-        linkify: true,
-        transformCopiedText: true,
-        transformPastedText: true,
-      }),
+      Markdown,
       Image,
       Link,
       Placeholder.configure({
@@ -75,6 +62,7 @@ export function RichTextEditor({
       }),
     ],
     content: defaultValue,
+    contentType: 'markdown',
     onUpdate: handleChange,
     editorProps: {
       attributes: {
@@ -84,8 +72,8 @@ export function RichTextEditor({
   })
 
   useEffect(() => {
-    if (editor.storage.markdown.getMarkdown() === '' || !editor.storage.markdown.getMarkdown()) {
-      editor.commands.setContent(defaultValue)
+    if (editor.getMarkdown() === '' || !editor.getMarkdown()) {
+      editor.commands.setContent(defaultValue, { contentType: 'markdown' })
     }
   }, [defaultValue, editor])
 

--- a/lib/src/Components/Input/RichTextEditor.tsx
+++ b/lib/src/Components/Input/RichTextEditor.tsx
@@ -19,7 +19,6 @@ interface RichTextEditorProps {
   updateFormValue?: (value: string) => void
 }
 
-
 /**
  * @category Input
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,11 +146,11 @@
         "@maplibre/maplibre-gl-leaflet": "^0.1.3",
         "@tiptap/core": "^3.13.0",
         "@tiptap/extension-bubble-menu": "^3.13.0",
-        "@tiptap/extension-color": "^3.13.0",
         "@tiptap/extension-image": "^3.13.0",
         "@tiptap/extension-link": "^3.13.0",
         "@tiptap/extension-placeholder": "^3.13.0",
         "@tiptap/extension-youtube": "^3.13.0",
+        "@tiptap/markdown": "^3.15.3",
         "@tiptap/pm": "^3.6.5",
         "@tiptap/react": "^3.13.0",
         "@tiptap/starter-kit": "^3.13.0",
@@ -173,7 +173,6 @@
         "react-qr-code": "^2.0.16",
         "react-toastify": "^9.1.3",
         "remark-breaks": "^4.0.0",
-        "tiptap-markdown": "^0.9.0",
         "yet-another-react-lightbox": "^3.28.0"
       },
       "devDependencies": {
@@ -4218,16 +4217,16 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.13.0.tgz",
-      "integrity": "sha512-iUelgiTMgPVMpY5ZqASUpk8mC8HuR9FWKaDzK27w9oWip9tuB54Z8mePTxNcQaSPb6ErzEaC8x8egrRt7OsdGQ==",
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.15.3.tgz",
+      "integrity": "sha512-bmXydIHfm2rEtGju39FiQNfzkFx9CDvJe+xem1dgEZ2P6Dj7nQX9LnA1ZscW7TuzbBRkL5p3dwuBIi3f62A66A==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.13.0"
+        "@tiptap/pm": "^3.15.3"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
@@ -4311,19 +4310,6 @@
       "peerDependencies": {
         "@tiptap/core": "^3.13.0",
         "@tiptap/pm": "^3.13.0"
-      }
-    },
-    "node_modules/@tiptap/extension-color": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-3.13.0.tgz",
-      "integrity": "sha512-I+PTZ31p6GhCjUVpCh1qertTK6T07MVGuLm/LP+c14ByMoZ0L0nVgw0YbWhDqLYWbkI9davv0fuI3dQ0gKSPlA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-text-style": "^3.13.0"
       }
     },
     "node_modules/@tiptap/extension-document": {
@@ -4569,20 +4555,6 @@
         "@tiptap/core": "^3.13.0"
       }
     },
-    "node_modules/@tiptap/extension-text-style": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.13.0.tgz",
-      "integrity": "sha512-M7ob3pfYNYgFPihncEp33r9477hXQgC8j3iU8BsewvPlSx2bMSy5jp2XHDXyEX8dV6flr7acH4GkXXw+DHpaPA==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.13.0"
-      }
-    },
     "node_modules/@tiptap/extension-underline": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.13.0.tgz",
@@ -4623,10 +4595,27 @@
         "@tiptap/pm": "^3.13.0"
       }
     },
+    "node_modules/@tiptap/markdown": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/markdown/-/markdown-3.15.3.tgz",
+      "integrity": "sha512-JjjZ/X7H2+/Jeapk8GurbncJVyG9ai5YD/eJLBKDyWqsoQwsrHbDlYBx26q9J5VwWXzxe9G6fmHNlAfw0Pokow==",
+      "license": "MIT",
+      "dependencies": {
+        "marked": "^15.0.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.15.3",
+        "@tiptap/pm": "^3.15.3"
+      }
+    },
     "node_modules/@tiptap/pm": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.13.0.tgz",
-      "integrity": "sha512-WKR4ucALq+lwx0WJZW17CspeTpXorbIOpvKv5mulZica6QxqfMhn8n1IXCkDws/mCoLRx4Drk5d377tIjFNsvQ==",
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.15.3.tgz",
+      "integrity": "sha512-Zm1BaU1TwFi3CQiisxjgnzzIus+q40bBKWLqXf6WEaus8Z6+vo1MT2pU52dBCMIRaW9XNDq3E5cmGtMc1AlveA==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
@@ -10885,11 +10874,17 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
-    "node_modules/markdown-it-task-lists": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
-      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==",
-      "license": "ISC"
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -15010,46 +15005,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/tiptap-markdown": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/tiptap-markdown/-/tiptap-markdown-0.9.0.tgz",
-      "integrity": "sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==",
-      "license": "MIT",
-      "workspaces": [
-        "example"
-      ],
-      "dependencies": {
-        "@types/markdown-it": "^13.0.7",
-        "markdown-it": "^14.1.0",
-        "markdown-it-task-lists": "^2.1.1",
-        "prosemirror-markdown": "^1.11.1"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.0.1"
-      }
-    },
-    "node_modules/tiptap-markdown/node_modules/@types/linkify-it": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
-      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
-      "license": "MIT"
-    },
-    "node_modules/tiptap-markdown/node_modules/@types/markdown-it": {
-      "version": "13.0.9",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.9.tgz",
-      "integrity": "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/linkify-it": "^3",
-        "@types/mdurl": "^1"
-      }
-    },
-    "node_modules/tiptap-markdown/node_modules/@types/mdurl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
-      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
-      "license": "MIT"
     },
     "node_modules/tldts": {
       "version": "6.1.86",


### PR DESCRIPTION
## Summary

- Replace community `tiptap-markdown` with official `@tiptap/markdown` extension
- Use new API: `editor.getMarkdown()` instead of `editor.storage.markdown.getMarkdown()`
- Add `contentType: 'markdown'` for direct markdown loading
- Remove unused `@tiptap/extension-color` (no UI was using it)

## Why

The official `@tiptap/markdown` extension provides better integration and is actively maintained by the TipTap team. The community package `tiptap-markdown` has a different API and is a separate dependency.

## Test plan

- [x] Build lib successfully
- [x] Build app successfully
- [x] Test RichTextEditor: create/edit profile with formatted text
- [x] Verify markdown is correctly saved and loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)