### PR TITLE
feat(app): add login button to info modal

### DIFF
--- a/app/src/ModalContent.tsx
+++ b/app/src/ModalContent.tsx
@@ -5,7 +5,8 @@
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 
 import { useEffect, useState } from 'react'
-import { TextView } from 'utopia-ui'
+import { useNavigate } from 'react-router-dom'
+import { TextView, useAuth } from 'utopia-ui'
 
 import { config } from './config'
 
@@ -15,20 +16,35 @@ interface ChapterProps {
 }
 
 export function Welcome1({ clickAction1, map }: ChapterProps) {
+  const { isAuthenticated } = useAuth()
+  const navigate = useNavigate()
+
   return (
     <>
       {map.custom_text ? (
         <>
           <TextView rawText={map.custom_text}></TextView>
-          <div className='tw:grid'>
-            <label
-              className='tw:btn tw:btn-primary tw:place-self-end tw:mt-4'
-              onClick={() => {
-                clickAction1()
-              }}
-            >
-              Close
-            </label>
+          <div className='tw:grid tw:mt-4'>
+            {isAuthenticated ? (
+              <label
+                className='tw:btn tw:btn-primary tw:place-self-end'
+                onClick={() => {
+                  clickAction1()
+                }}
+              >
+                Close
+              </label>
+            ) : (
+              <label
+                className='tw:btn tw:btn-primary tw:place-self-end'
+                onClick={() => {
+                  clickAction1()
+                  void navigate('/login')
+                }}
+              >
+                Login
+              </label>
+            )}
           </div>
         </>
       ) : (
@@ -45,15 +61,27 @@ export function Welcome1({ clickAction1, map }: ChapterProps) {
             Join us and grow the network by adding projects and events to the map.
           </p>
           <p className='tw:py-1'>Create your personal profile and place it on the map.</p>
-          <div className='tw:grid'>
-            <label
-              className='tw:btn tw:btn-primary tw:place-self-end tw:mt-4'
-              onClick={() => {
-                clickAction1()
-              }}
-            >
-              Close
-            </label>
+          <div className='tw:grid tw:mt-4'>
+            {isAuthenticated ? (
+              <label
+                className='tw:btn tw:btn-primary tw:place-self-end'
+                onClick={() => {
+                  clickAction1()
+                }}
+              >
+                Close
+              </label>
+            ) : (
+              <label
+                className='tw:btn tw:btn-primary tw:place-self-end'
+                onClick={() => {
+                  clickAction1()
+                  void navigate('/login')
+                }}
+              >
+                Login
+              </label>
+            )}
           </div>
         </>
       )}

--- a/lib/src/Components/Auth/index.tsx
+++ b/lib/src/Components/Auth/index.tsx
@@ -1,4 +1,4 @@
-export { AuthProvider } from './useAuth'
+export { AuthProvider, useAuth } from './useAuth'
 export { LoginPage } from './LoginPage'
 export { SignupPage } from './SignupPage'
 export { RequestPasswordPage } from './RequestPasswordPage'


### PR DESCRIPTION
## Summary
- Shows a **Login** button in the info modal when the user is not authenticated
- Replaces the Close button — logged-in users see Close, guests see Login
- Clicking Login closes the modal and navigates to `/login`
- Exports `useAuth` hook from `utopia-ui` for app-level usage

Requested by Ocean Nomads.

## Test plan
- [ ] Open map as guest → info modal shows "Login" button
- [ ] Click Login → modal closes, navigates to `/login`
- [ ] Log in → reopen info modal → shows "Close" button
- [ ] Works with both `custom_text` maps and default maps

🤖 Generated with [Claude Code](https://claude.com/claude-code)