### PR TITLE
feat(app): auto-start geolocation after login

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -207,6 +207,7 @@ function App() {
             embedded={embedded}
             openCollectiveApiKey={config.openCollectiveApiKey}
             hideSignup={map.hide_signup}
+            autoLocateOnLogin={map.auto_locate_on_login}
           >
             <Permissions api={permissionsApiInstance} adminRole={config.adminRole} />
             {tagsApi && <Tags api={tagsApi}></Tags>}

--- a/backend/directus-config/development/snapshot/fields/maps/auto_locate_on_login.json
+++ b/backend/directus-config/development/snapshot/fields/maps/auto_locate_on_login.json
@@ -8,21 +8,21 @@
     "display": null,
     "display_options": null,
     "field": "auto_locate_on_login",
-    "group": null,
+    "group": "Presets",
     "hidden": false,
     "interface": "boolean",
     "note": "Automatically start geolocation after user login",
     "options": null,
     "readonly": false,
     "required": false,
-    "sort": 17,
+    "sort": 3,
     "special": [
       "cast-boolean"
     ],
     "translations": null,
     "validation": null,
     "validation_message": null,
-    "width": "full"
+    "width": "half"
   },
   "schema": {
     "name": "auto_locate_on_login",

--- a/backend/directus-config/development/snapshot/fields/maps/auto_locate_on_login.json
+++ b/backend/directus-config/development/snapshot/fields/maps/auto_locate_on_login.json
@@ -1,0 +1,45 @@
+{
+  "collection": "maps",
+  "field": "auto_locate_on_login",
+  "type": "boolean",
+  "meta": {
+    "collection": "maps",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "auto_locate_on_login",
+    "group": null,
+    "hidden": false,
+    "interface": "boolean",
+    "note": "Automatically start geolocation after user login",
+    "options": null,
+    "readonly": false,
+    "required": false,
+    "sort": 17,
+    "special": [
+      "cast-boolean"
+    ],
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "full"
+  },
+  "schema": {
+    "name": "auto_locate_on_login",
+    "table": "maps",
+    "data_type": "boolean",
+    "default_value": false,
+    "max_length": null,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}

--- a/lib/src/Components/AppShell/AppShell.tsx
+++ b/lib/src/Components/AppShell/AppShell.tsx
@@ -16,6 +16,7 @@ export function AppShell({
   embedded,
   openCollectiveApiKey,
   hideSignup,
+  autoLocateOnLogin,
 }: {
   appName: string
   children: React.ReactNode
@@ -23,6 +24,7 @@ export function AppShell({
   embedded?: boolean
   openCollectiveApiKey?: string
   hideSignup?: boolean
+  autoLocateOnLogin?: boolean
 }) {
   return (
     <ContextWrapper>
@@ -32,6 +34,7 @@ export function AppShell({
           embedded={embedded}
           openCollectiveApiKey={openCollectiveApiKey}
           hideSignup={hideSignup}
+          autoLocateOnLogin={autoLocateOnLogin}
         />
         <NavBar appName={appName}></NavBar>
         <div id='app-content' className='tw:flex'>

--- a/lib/src/Components/AppShell/SetAppState.tsx
+++ b/lib/src/Components/AppShell/SetAppState.tsx
@@ -9,11 +9,13 @@ export const SetAppState = ({
   embedded,
   openCollectiveApiKey,
   hideSignup,
+  autoLocateOnLogin,
 }: {
   assetsApi: AssetsApi
   embedded?: boolean
   openCollectiveApiKey?: string
   hideSignup?: boolean
+  autoLocateOnLogin?: boolean
 }) => {
   const setAppState = useSetAppState()
 
@@ -32,6 +34,10 @@ export const SetAppState = ({
   useEffect(() => {
     setAppState({ hideSignup: hideSignup ?? false })
   }, [hideSignup, setAppState])
+
+  useEffect(() => {
+    setAppState({ autoLocateOnLogin: autoLocateOnLogin ?? false })
+  }, [autoLocateOnLogin, setAppState])
 
   return <></>
 }

--- a/lib/src/Components/AppShell/hooks/useAppState.tsx
+++ b/lib/src/Components/AppShell/hooks/useAppState.tsx
@@ -11,6 +11,7 @@ interface AppState {
   embedded: boolean
   openCollectiveApiKey: string
   hideSignup: boolean
+  autoLocateOnLogin: boolean
 }
 
 type UseAppManagerResult = ReturnType<typeof useAppManager>
@@ -23,6 +24,7 @@ const initialAppState: AppState = {
   embedded: false,
   openCollectiveApiKey: '',
   hideSignup: false,
+  autoLocateOnLogin: false,
 }
 
 const AppContext = createContext<UseAppManagerResult>({

--- a/lib/src/Components/Map/Subcomponents/Controls/LocateControl.tsx
+++ b/lib/src/Components/Map/Subcomponents/Controls/LocateControl.tsx
@@ -49,6 +49,7 @@ export const LocateControl = (): React.JSX.Element => {
   // Only start tracking user changes after initial auth check completes,
   // so page reload (user: null → restored session) is not mistaken for a login
   const authReadyRef = useRef(false)
+  const hasAutoLocatedRef = useRef(false)
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
   const [lc, setLc] = useState<any>(null)
@@ -101,15 +102,16 @@ export const LocateControl = (): React.JSX.Element => {
     }
   }, [isInitialized])
 
-  // Auto-start location tracking after login (configurable per map)
+  // Auto-start location tracking after login (configurable per map, fires once)
   useEffect(() => {
-    if (autoLocateOnLogin && authReadyRef.current && user && lc && !active) {
+    if (autoLocateOnLogin && authReadyRef.current && !hasAutoLocatedRef.current && user && lc) {
+      hasAutoLocatedRef.current = true
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       lc.start()
       setLoading(true)
       setHasDeclinedModal(false)
     }
-  }, [user, lc, active, autoLocateOnLogin])
+  }, [user, lc, autoLocateOnLogin])
 
   // Check if user logged in while location is active and found
   useEffect(() => {

--- a/lib/src/Components/Map/Subcomponents/Controls/LocateControl.tsx
+++ b/lib/src/Components/Map/Subcomponents/Controls/LocateControl.tsx
@@ -40,13 +40,15 @@ export const LocateControl = (): React.JSX.Element => {
   const updateItem = useUpdateItem()
   const addItem = useAddItem()
   const layers = useLayers()
-  const { user } = useAuth()
+  const { user, isInitialized } = useAuth()
   const { autoLocateOnLogin } = useAppState()
   const navigate = useNavigate()
 
   // Prevent React 18 StrictMode from calling useEffect twice
   const init = useRef(false)
-  const prevUserRef = useRef(user)
+  // Only start tracking user changes after initial auth check completes,
+  // so page reload (user: null → restored session) is not mistaken for a login
+  const authReadyRef = useRef(false)
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
   const [lc, setLc] = useState<any>(null)
@@ -92,15 +94,21 @@ export const LocateControl = (): React.JSX.Element => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // Mark auth as ready once initial check completes (distinguishes reload from login)
+  useEffect(() => {
+    if (isInitialized && !authReadyRef.current) {
+      authReadyRef.current = true
+    }
+  }, [isInitialized])
+
   // Auto-start location tracking after login (configurable per map)
   useEffect(() => {
-    if (autoLocateOnLogin && !prevUserRef.current && user && lc && !active) {
+    if (autoLocateOnLogin && authReadyRef.current && user && lc && !active) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       lc.start()
       setLoading(true)
       setHasDeclinedModal(false)
     }
-    prevUserRef.current = user
   }, [user, lc, active, autoLocateOnLogin])
 
   // Check if user logged in while location is active and found

--- a/lib/src/Components/Map/Subcomponents/Controls/LocateControl.tsx
+++ b/lib/src/Components/Map/Subcomponents/Controls/LocateControl.tsx
@@ -46,10 +46,10 @@ export const LocateControl = (): React.JSX.Element => {
 
   // Prevent React 18 StrictMode from calling useEffect twice
   const init = useRef(false)
-  // Only start tracking user changes after initial auth check completes,
-  // so page reload (user: null → restored session) is not mistaken for a login
-  const authReadyRef = useRef(false)
+  // Track whether auto-locate has already fired (one-shot per session)
   const hasAutoLocatedRef = useRef(false)
+  // Snapshot of user after initial auth completes — changes after this are real logins
+  const initialUserRef = useRef<typeof user>(undefined)
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
   const [lc, setLc] = useState<any>(null)
@@ -95,23 +95,27 @@ export const LocateControl = (): React.JSX.Element => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Mark auth as ready once initial check completes (distinguishes reload from login)
+  // Auto-start location tracking after a real login (not page reload)
   useEffect(() => {
-    if (isInitialized && !authReadyRef.current) {
-      authReadyRef.current = true
-    }
-  }, [isInitialized])
+    if (!isInitialized || !autoLocateOnLogin || !lc) return
 
-  // Auto-start location tracking after login (configurable per map, fires once)
-  useEffect(() => {
-    if (autoLocateOnLogin && authReadyRef.current && !hasAutoLocatedRef.current && user && lc) {
+    // First time isInitialized is true: snapshot the current user as baseline
+    if (initialUserRef.current === undefined) {
+      initialUserRef.current = user
+      return
+    }
+
+    // If user changed from null to a value after the baseline was set, it's a real login
+    if (!hasAutoLocatedRef.current && user && initialUserRef.current === null) {
       hasAutoLocatedRef.current = true
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       lc.start()
       setLoading(true)
       setHasDeclinedModal(false)
     }
-  }, [user, lc, autoLocateOnLogin])
+
+    initialUserRef.current = user
+  }, [isInitialized, user, lc, autoLocateOnLogin])
 
   // Check if user logged in while location is active and found
   useEffect(() => {

--- a/lib/src/Components/Map/Subcomponents/Controls/LocateControl.tsx
+++ b/lib/src/Components/Map/Subcomponents/Controls/LocateControl.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router-dom'
 import { toast } from 'react-toastify'
 
 import TargetSVG from '#assets/target.svg'
+import { useAppState } from '#components/AppShell/hooks/useAppState'
 import { useAuth } from '#components/Auth/useAuth'
 import { useAddItem, useUpdateItem } from '#components/Map/hooks/useItems'
 import { useLayers } from '#components/Map/hooks/useLayers'
@@ -40,10 +41,12 @@ export const LocateControl = (): React.JSX.Element => {
   const addItem = useAddItem()
   const layers = useLayers()
   const { user } = useAuth()
+  const { autoLocateOnLogin } = useAppState()
   const navigate = useNavigate()
 
   // Prevent React 18 StrictMode from calling useEffect twice
   const init = useRef(false)
+  const prevUserRef = useRef(user)
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
   const [lc, setLc] = useState<any>(null)
@@ -88,6 +91,17 @@ export const LocateControl = (): React.JSX.Element => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Auto-start location tracking after login (configurable per map)
+  useEffect(() => {
+    if (autoLocateOnLogin && !prevUserRef.current && user && lc && !active) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      lc.start()
+      setLoading(true)
+      setHasDeclinedModal(false)
+    }
+    prevUserRef.current = user
+  }, [user, lc, active, autoLocateOnLogin])
 
   // Check if user logged in while location is active and found
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Adds configurable `auto_locate_on_login` boolean to the maps collection in Directus
- When enabled, geolocation tracking starts automatically after user login
- Triggers the existing location update flow (center map + ask to set profile position)
- Off by default — can be toggled per map instance in Directus

## Changes
- **Backend**: New `auto_locate_on_login` field in maps collection snapshot
- **Lib**: `autoLocateOnLogin` in AppState, threaded through AppShell → SetAppState → LocateControl
- **App**: Passes `map.auto_locate_on_login` from Directus config to AppShell

Requested by Ocean Nomads.

## Test plan
- [ ] Run `directus-sync push` to create the new field in Directus
- [ ] Enable `auto_locate_on_login` for a map in Directus
- [ ] Log in → geolocation starts automatically → location modal appears
- [ ] Verify it does NOT auto-locate when the flag is off (default)
- [ ] Verify manual locate button still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)