### PR TITLE
fix(app): only show startup info modal on initial root load

### DIFF
--- a/app/src/ModalContent.tsx
+++ b/app/src/ModalContent.tsx
@@ -99,6 +99,8 @@ const close = () => {
 export const ModalContent = ({ map }: { map: any }) => {
   const { pathname } = useLocation()
   const autoOpenedModal = useRef(false)
+  const hasHandledStartupModal = useRef(false)
+  const initialPathname = useRef(pathname)
 
   useEffect(() => {
     const myModal = document.getElementById('my_modal_3')
@@ -106,10 +108,14 @@ export const ModalContent = ({ map }: { map: any }) => {
       return
     }
 
-    if (map.info_open && pathname === ROOT_PATH && !myModal.open) {
-      myModal.showModal()
-      autoOpenedModal.current = true
-      return
+    if (!hasHandledStartupModal.current) {
+      hasHandledStartupModal.current = true
+
+      if (map.info_open && initialPathname.current === ROOT_PATH && !myModal.open) {
+        myModal.showModal()
+        autoOpenedModal.current = true
+        return
+      }
     }
 
     if (pathname !== ROOT_PATH && autoOpenedModal.current && myModal.open) {

--- a/cypress/e2e/authentification/set-new-password.cy.ts
+++ b/cypress/e2e/authentification/set-new-password.cy.ts
@@ -30,6 +30,20 @@ describe('Utopia Map Authentication Set New Password', () => {
     cy.get('dialog#my_modal_3').should('not.have.attr', 'open')
   })
 
+  it('should not open the startup info modal when returning to root after the initial reset route', () => {
+    cy.visit('/set-new-password?token=test-reset-token')
+    cy.wait('@getMap')
+
+    cy.contains('h2', 'Set new Password')
+      .parent()
+      .within(() => {
+        cy.contains('button', '✕').click()
+      })
+
+    cy.location('pathname').should('eq', '/')
+    cy.get('dialog#my_modal_3').should('not.have.attr', 'open')
+  })
+
   it('should still open the startup info modal on the root route', () => {
     cy.visit('/')
     cy.wait('@getMap')


### PR DESCRIPTION
Fixes follow-up after #857.

The startup info modal is now evaluated only once when ModalContent mounts. It opens only if the initial route was /, so navigating back to / from /set-new-password or other in-app routes no longer pops the welcome dialog.

Verification:
- npm --workspace app run build
- ../node_modules/.bin/eslint src/ModalContent.tsx from app/
- git diff --check

Not run:
- Cypress E2E, because local app/backend were not running on http://localhost:8080 / http://localhost:8055.
- npm --prefix cypress run lint, because local cypress dependencies are incomplete: eslint-plugin-cypress is missing.