### PR TITLE
chore(docker): dev-setup polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ docker compose up -d
 **Initialize backend**
 
 ```bash
-sudo chmod 777 -R  ./data/
 cd backend/
 ./push.sh
 ./seed.sh

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.20.0-alpine as third-party-ext
+FROM node:22.20.0-alpine AS third-party-ext
 RUN apk add python3 g++ make
 WORKDIR /extensions
 ADD extensions .

--- a/backend/README.md
+++ b/backend/README.md
@@ -16,7 +16,7 @@ In order to pull data from your locally running backend (see [docker-compose](..
 
 
 ```
-npx directus-sync pull \
+npx directus-sync@3.5.1 pull \
   --dump-path ./directus-config/development \
   --directus-url http://localhost:8055 \
   --directus-email admin@it4c.dev \
@@ -29,7 +29,7 @@ You can run `./pull.sh` to run this command and modify it via `export PROJECT=..
 
 To push local changes or to seed directus use the following command
 ```
-npx directus-sync push \
+npx directus-sync@3.5.1 push \
   --dump-path ./directus-config/development \
   --directus-url http://localhost:8055 \
   --directus-email admin@it4c.dev \
@@ -73,11 +73,11 @@ echo "REASSIGN OWNED BY admin TO directus" | docker exec -i utopia-map-database-
 
 ## Access Data on local drive
 
-In order to access the postgress data mounted to the local drive at `/data/database` you need to make it accessible (assuming you are not root):
+In order to access the postgres data mounted to the local drive at `./data/database` you need to make it accessible (assuming you are not root):
 ```
-sudo chmod 777 -R ./data/
+sudo chmod -R 777 ./data/database
 ```
 
-This process is to be repeated whenever you restart the database docker container
+This process is to be repeated whenever you restart the database docker container.
 
-The same applies for the uploads and extension folder - ensure that the folder is writeable or file uploads will fail.
+The `./data/uploads` folder is taken care of automatically by the `init-uploads` service in `docker-compose.yml`, which runs once before the backend starts and makes the directory writeable. No manual chmod needed.

--- a/backend/directus-sync.config.json
+++ b/backend/directus-sync.config.json
@@ -1,0 +1,3 @@
+{
+  "dumpPath": "./directus-config/development"
+}

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -163,7 +163,10 @@ docker compose down && docker compose up -d
 docker compose down && sudo rm -rf ./data/database && docker compose up -d
 ```
 
-**Permission denied on ./data**
+**Permission denied on ./data/database**
 ```bash
-sudo chmod 777 -R ./data
+sudo chmod -R 777 ./data/database
 ```
+
+(The `./data/uploads` directory is fixed automatically by the
+`init-uploads` service in `docker-compose.yml`.)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,16 @@ services:
     volumes:
       - ./app/dist:/srv:ro
 
+  # One-shot helper that runs before the backend starts.
+  # Ensures ./data/uploads exists and is writeable by the Directus
+  # container (which runs as a non-root user). Without this, a fresh
+  # checkout fails on a permission-denied error.
+  init-uploads:
+    image: busybox
+    command: ["sh", "-c", "mkdir -p /uploads && chmod -R 777 /uploads"]
+    volumes:
+      - ./data/uploads:/uploads
+
   database:
     image: postgis/postgis:13-master
     volumes:
@@ -41,6 +51,8 @@ services:
         condition: service_healthy
       cache:
         condition: service_healthy
+      init-uploads:
+        condition: service_completed_successfully
     ports:
       - 8055:8055
     volumes:


### PR DESCRIPTION
## Summary

Three small follow-ups to #859 that smooth out the local dev experience without changing how production is run.

### Commit 1 — Dockerfile casing + trailing newline

Resolves the `FromAsCasing` buildkit warning that's been ticking on every build, plus the missing final newline.

### Commit 2 — `backend/directus-sync.config.json`

`directus-sync` printed `[config] No config file found. Tried path: …` on every invocation. Adding a minimal config file silences that and gives us a single place for sync defaults that aren't environment-specific.

### Commit 3 — `init-uploads` service auto-fixes permissions

A fresh checkout (or a `sudo rm -rf data/` reset) hits

    EACCES: permission denied, open '/directus/uploads/directus-health-file'

because the host-side `./data/uploads` is root-owned while the Directus container runs as a non-root user. Adding a one-shot busybox service that runs before the backend (`service_completed_successfully` gate) and `chmod`s the directory removes the manual `sudo chmod 777 -R ./data/` step from the README.

## Test plan

- [ ] Fresh checkout + `docker compose up -d --build` + `cd backend && ./push.sh && ./seed.sh` succeeds without manual chmod
- [ ] No more `[config] No config file found` log from directus-sync
- [ ] No more `FromAsCasing` warning from docker build

🤖 Generated with [Claude Code](https://claude.com/claude-code)